### PR TITLE
Include mypy generated code in caraml-upi-protos

### DIFF
--- a/gen/python/grpc/setup.py
+++ b/gen/python/grpc/setup.py
@@ -18,7 +18,7 @@ TEST_REQUIRES = [
 
 setup(
     name=NAME,
-    version=VERSION,
+    version="0.0.6",
     description="Generated Python code from caraml-dev/universal-prediction-interface",  
     author="CaraML Developer",
     author_email="dsp@gojek.com",
@@ -28,6 +28,7 @@ setup(
     install_requires=REQUIRES,
     extras_require={ "test": TEST_REQUIRES },
     packages=find_packages(exclude=["test"]),
+    package_data={"caraml.upi.v1": ["*.pyi"]},
     long_description=open("README.md").read(),
     long_description_content_type='text/markdown',
 )

--- a/gen/python/grpc/setup.py
+++ b/gen/python/grpc/setup.py
@@ -18,7 +18,7 @@ TEST_REQUIRES = [
 
 setup(
     name=NAME,
-    version="0.0.6",
+    version=VERSION,
     description="Generated Python code from caraml-dev/universal-prediction-interface",  
     author="CaraML Developer",
     author_email="dsp@gojek.com",


### PR DESCRIPTION
Include generated code from mypy plugin to allow autocompletion when working with classes in caraml-upi-protos package. 
Without this, it's very difficult to work with python code generated by protobuf.


<img width="558" alt="Screenshot 2022-08-31 at 4 30 00 PM" src="https://user-images.githubusercontent.com/4023015/187633103-f2f7391a-173d-4e4d-819b-9b948f3d71f8.png">
