### PR TITLE
Add continuous benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,4 +46,23 @@ jobs:
         run: pip install -e .[test]
       - name: Run test
         working-directory: ./gen/python/grpc
-        run: pytest
+        run: pytest --benchmark-disable
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        working-directory: ./gen/python/grpc
+        run: pip install -e .[test]
+      - name: Run test
+        working-directory: ./gen/python/grpc
+        run: pytest --benchmark-json output.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: output.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.7"
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
       - name: Install dependencies
         working-directory: ./gen/python/grpc
         run: pip install -e .[test]
@@ -66,3 +71,5 @@ jobs:
         with:
           tool: 'pytest'
           output-file-path: ./gen/python/grpc/output.json
+          external-data-json-path: ./cache/benchmark-data.json
+          fail-on-alert: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,4 +65,4 @@ jobs:
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
-          output-file-path: output.json
+          output-file-path: ./gen/python/grpc/output.json

--- a/.github/workflows/publish-benchmark.yaml
+++ b/.github/workflows/publish-benchmark.yaml
@@ -1,0 +1,27 @@
+name: Publish Benchmark
+on:
+  push:
+    branches:
+      - master
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        working-directory: ./gen/python/grpc
+        run: pip install -e .[test]
+      - name: Run test
+        working-directory: ./gen/python/grpc
+        run: pytest --benchmark-json output.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: ./gen/python/grpc/output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true


### PR DESCRIPTION
This PR add continuous benchmark validation and report publishing using https://github.com/benchmark-action/github-action-benchmark.  
- Every pull request will be checked against performance regression and will fail if the performance degrade by more than 2x.
- Once a PR is merge to master, a benchmark report will be created and published in https://caraml-dev.github.io/universal-prediction-interface/dev/bench/