### PR TITLE
Add utility function to convert table to dict

### DIFF
--- a/gen/python/grpc/caraml/upi/utils.py
+++ b/gen/python/grpc/caraml/upi/utils.py
@@ -99,14 +99,21 @@ def table_to_df(table: table_pb2.Table) -> Tuple[pd.DataFrame, str]:
 
     return pd.DataFrame(columns=columns, data=rows_values, index=indices), table.name
 
+def table_to_dict(table: table_pb2.Table, format: DictValuesType) -> Union[List[Dict[str, Any]], Dict[str, Any]]: 
+    """
+    Convert upi table into dict with certain value type
 
-def get_columns_types(table: table_pb2.Table):
-    columns = [column.name for column in table.columns]
-    types = [column.type for column in table.columns]
-    return columns, types
+    Usage:
 
+    >>> dict = table_to_dict(upi_table, DictValuesType.RECORDS)
 
-def table_to_dict(table: table_pb2.Table, format: DictValuesType):
+    Args:
+        table (table_pb2.Table): upi table
+        format (DictValuesType): value type of dictionary
+
+    Returns: Union[List[Dict[str, Any]], Dict[str, Any]]
+    The return type can be `dictionary` or `array of dictionary`
+    """
     if format == DictValuesType.DICT:
         return __table_to_dict_value_type(table)       
     elif format == DictValuesType.RECORDS:

--- a/gen/python/grpc/test/benchmark_utils_test.py
+++ b/gen/python/grpc/test/benchmark_utils_test.py
@@ -3,7 +3,7 @@ import uuid
 import pandas as pd
 import pytest
 
-from caraml.upi.utils import df_to_table, table_to_df
+from caraml.upi.utils import df_to_table, table_to_df, table_to_dict, DictValuesType
 
 bench_utils_test_cases = [
     (1, 1),
@@ -29,6 +29,57 @@ def test_benchmark_table_to_df(n_rows, n_cols, benchmark):
     df = create_df(n_rows, n_cols)
     table = df_to_table(df, "benchmark_table")
     benchmark(table_to_df, table)
+
+
+def table_to_df_to_dict(table, value_type):
+    df, _ = table_to_df(table)
+    return df.to_dict(value_type)
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_df_to_dict_records")
+def test_benchmark_table_to_df_to_dict_records(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_df_to_dict, table, "records")
+
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_dict_records")
+def test_benchmark_table_to_dict_records(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_dict, table, DictValuesType.RECORDS)
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_df_to_dict_split")
+def test_benchmark_table_to_df_to_dict_split(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_df_to_dict, table, "split")
+
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_dict_split")
+def test_benchmark_table_to_dict_split(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_dict, table, DictValuesType.SPLIT)
+
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_df_to_dict_type")
+def test_benchmark_table_to_df_to_dict_type(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_df_to_dict, table, "dict")
+
+
+@pytest.mark.parametrize("n_rows,n_cols", bench_utils_test_cases)
+@pytest.mark.benchmark(group="table_to_dict_type")
+def test_benchmark_table_to_dict_type(n_rows, n_cols, benchmark):
+    df = create_df(n_rows, n_cols)
+    table = df_to_table(df, "benchmark_table")
+    benchmark(table_to_dict, table, DictValuesType.DICT)
 
 
 def create_df(n_rows, n_cols) -> pd.DataFrame:

--- a/gen/python/grpc/test/utils_test.py
+++ b/gen/python/grpc/test/utils_test.py
@@ -153,12 +153,12 @@ test_cases = [
                 table_pb2.Row(row_id="1",
                                 values=[
                                     table_pb2.Value(integer_value=222),
-                                    table_pb2.Value(double_value=10.1)
+                                    table_pb2.Value(is_null=True)
                                 ])
             ]
         ),
         DictValuesType.DICT,
-        {"int_col": {"0": 111, "1": 222}, "double_col":{"0": 12.2, "1":10.1}}
+        {"int_col": {"0": 111, "1": 222}, "double_col":{"0": 12.2, "1": np.NaN}}
     ),
     (
         table_pb2.Table(
@@ -173,12 +173,12 @@ test_cases = [
                 table_pb2.Row(row_id="1",
                                 values=[
                                     table_pb2.Value(integer_value=222),
-                                    table_pb2.Value(double_value=10.1)
+                                    table_pb2.Value(is_null=True)
                                 ])
             ]
         ),
         DictValuesType.RECORDS,
-        [{"int_col": 111, "double_col": 12.2}, {"int_col": 222, "double_col": 10.1}]
+        [{"int_col": 111, "double_col": 12.2}, {"int_col": 222, "double_col": np.NaN}]
     ),
     (
         table_pb2.Table(
@@ -193,12 +193,12 @@ test_cases = [
                 table_pb2.Row(row_id="1",
                                 values=[
                                     table_pb2.Value(integer_value=222),
-                                    table_pb2.Value(double_value=10.1)
+                                    table_pb2.Value(is_null=True)
                                 ])
             ]
         ),
         DictValuesType.SPLIT,
-        {"index":["0", "1"], "columns":["int_col", "double_col"], "data":[[111, 12.2], [222, 10.1]]}
+        {"index":["0", "1"], "columns":["int_col", "double_col"], "data":[[111, 12.2], [222, np.NaN]]}
     )
 ]
 

--- a/gen/python/grpc/test/utils_test.py
+++ b/gen/python/grpc/test/utils_test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 import pandas as pd
-from caraml.upi.utils import df_to_table, table_to_df
+from caraml.upi.utils import df_to_table, table_to_df, DictValuesType, table_to_dict
 from caraml.upi.v1 import table_pb2, type_pb2
 
 conversion_test_cases = [
@@ -137,3 +137,72 @@ def test_table_to_df(exp_name, exp_df, table, cast):
     df, name = table_to_df(table)
     assert exp_df.equals(df)
     assert name == exp_name
+
+
+test_cases = [
+    (
+        table_pb2.Table(
+            name="int_table",
+            columns=[table_pb2.Column(name="int_col", type=type_pb2.TYPE_INTEGER), table_pb2.Column(name="double_col", type=type_pb2.TYPE_DOUBLE)],
+            rows=[
+                table_pb2.Row(row_id="0",
+                                values=[
+                                    table_pb2.Value(integer_value=111),
+                                    table_pb2.Value(double_value=12.2)
+                                ]),
+                table_pb2.Row(row_id="1",
+                                values=[
+                                    table_pb2.Value(integer_value=222),
+                                    table_pb2.Value(double_value=10.1)
+                                ])
+            ]
+        ),
+        DictValuesType.DICT,
+        {"int_col": {"0": 111, "1": 222}, "double_col":{"0": 12.2, "1":10.1}}
+    ),
+    (
+        table_pb2.Table(
+            name="int_table",
+            columns=[table_pb2.Column(name="int_col", type=type_pb2.TYPE_INTEGER), table_pb2.Column(name="double_col", type=type_pb2.TYPE_DOUBLE)],
+            rows=[
+                table_pb2.Row(row_id="0",
+                                values=[
+                                    table_pb2.Value(integer_value=111),
+                                    table_pb2.Value(double_value=12.2)
+                                ]),
+                table_pb2.Row(row_id="1",
+                                values=[
+                                    table_pb2.Value(integer_value=222),
+                                    table_pb2.Value(double_value=10.1)
+                                ])
+            ]
+        ),
+        DictValuesType.RECORDS,
+        [{"int_col": 111, "double_col": 12.2}, {"int_col": 222, "double_col": 10.1}]
+    ),
+    (
+        table_pb2.Table(
+            name="int_table",
+            columns=[table_pb2.Column(name="int_col", type=type_pb2.TYPE_INTEGER), table_pb2.Column(name="double_col", type=type_pb2.TYPE_DOUBLE)],
+            rows=[
+                table_pb2.Row(row_id="0",
+                                values=[
+                                    table_pb2.Value(integer_value=111),
+                                    table_pb2.Value(double_value=12.2)
+                                ]),
+                table_pb2.Row(row_id="1",
+                                values=[
+                                    table_pb2.Value(integer_value=222),
+                                    table_pb2.Value(double_value=10.1)
+                                ])
+            ]
+        ),
+        DictValuesType.SPLIT,
+        {"index":["0", "1"], "columns":["int_col", "double_col"], "data":[[111, 12.2], [222, 10.1]]}
+    )
+]
+
+@pytest.mark.parametrize("table,format,exp",test_cases)
+def test_table_to_dict(table, format, exp):
+    res = table_to_dict(table, format)
+    assert exp == res


### PR DESCRIPTION
Add new utility function:
* `table_to_dict`
This utility aims to give more performant conversion from table to dict without converting it to dataframe first

Benchmark result:

## RECORDS
```
------------------------------------------------------------------------------------------------- benchmark 'table_to_df_to_dict_records': 7 tests -------------------------------------------------------------------------------------------------
Name (time in us)                                                Min                     Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_df_to_dict_records[1-1]             299.9480 (1.0)          765.0700 (1.0)         332.0354 (1.0)         70.2161 (1.0)         310.1450 (1.0)          6.6190 (1.0)         43;76  3,011.7271 (1.0)         472           1
test_benchmark_table_to_df_to_dict_records[100-10]        1,745.0120 (5.82)       3,842.7350 (5.02)      1,950.9993 (5.88)       261.0142 (3.72)      1,841.1805 (5.94)       174.5695 (26.37)       62;54    512.5579 (0.17)        464           1
test_benchmark_table_to_df_to_dict_records[500-10]        5,656.6320 (18.86)      7,907.6000 (10.34)     6,085.0036 (18.33)      349.1868 (4.97)      6,004.2650 (19.36)      388.7790 (58.74)        33;8    164.3384 (0.05)        159           1
test_benchmark_table_to_df_to_dict_records[1000-10]      10,853.3570 (36.18)     16,182.8700 (21.15)    11,808.1548 (35.56)    1,094.5796 (15.59)    11,506.4535 (37.10)      961.8950 (145.32)        4;1     84.6872 (0.03)         30           1
test_benchmark_table_to_df_to_dict_records[100-100]      13,800.2230 (46.01)     17,344.9030 (22.67)    14,587.0990 (43.93)      637.8434 (9.08)     14,393.5910 (46.41)      640.0080 (96.69)        11;4     68.5537 (0.02)         69           1
test_benchmark_table_to_df_to_dict_records[500-100]      48,785.4870 (162.65)    52,681.1870 (68.86)    50,120.9746 (150.95)     984.5918 (14.02)    50,042.4780 (161.35)     940.7868 (142.13)        6;1     19.9517 (0.01)         19           1
test_benchmark_table_to_df_to_dict_records[1000-100]     92,655.9040 (308.91)   101,105.0030 (132.15)   95,045.2059 (286.25)   2,640.6302 (37.61)    94,409.4260 (304.40)   3,125.1635 (472.15)        2;1     10.5213 (0.00)         11           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


-------------------------------------------------------------------------------------------------- benchmark 'table_to_dict_records': 7 tests -------------------------------------------------------------------------------------------------
Name (time in us)                                          Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers           OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_dict_records[1-1]               4.1240 (1.0)         185.8500 (1.0)           4.9338 (1.0)          3.1314 (1.0)           4.5380 (1.0)          0.1760 (1.0)     1392;4259  202,682.8684 (1.0)       76641           1
test_benchmark_table_to_dict_records[100-10]          539.4190 (130.80)    1,145.8870 (6.17)        585.8000 (118.73)      67.1632 (21.45)       563.5785 (124.19)      25.4090 (144.37)    167;221    1,707.0673 (0.01)       1532           1
test_benchmark_table_to_dict_records[500-10]        2,720.7650 (659.74)    4,194.2590 (22.57)     3,013.8696 (610.86)     218.6667 (69.83)     2,939.8720 (647.83)     241.9620 (>1000.0)     69;11      331.7994 (0.00)        349           1
test_benchmark_table_to_dict_records[100-100]       4,720.3450 (>1000.0)   6,962.9880 (37.47)     5,139.7560 (>1000.0)    305.5363 (97.57)     5,056.2665 (>1000.0)    303.7080 (>1000.0)     40;10      194.5618 (0.00)        186           1
test_benchmark_table_to_dict_records[1000-10]       5,481.3900 (>1000.0)   7,241.4840 (38.96)     5,912.3038 (>1000.0)    315.0837 (100.62)    5,841.2830 (>1000.0)    287.1828 (>1000.0)     28;12      169.1388 (0.00)        159           1
test_benchmark_table_to_dict_records[500-100]      23,780.1600 (>1000.0)  26,893.3610 (144.70)   25,201.4549 (>1000.0)    714.5969 (228.21)   25,142.6530 (>1000.0)    519.9590 (>1000.0)      12;6       39.6802 (0.00)         37           1
test_benchmark_table_to_dict_records[1000-100]     50,069.1160 (>1000.0)  63,027.9270 (339.13)   53,292.9812 (>1000.0)  2,902.6818 (926.97)   53,031.2995 (>1000.0)  3,062.5365 (>1000.0)       4;1       18.7642 (0.00)         20           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## SPLIT 
```
------------------------------------------------------------------------------------------------- benchmark 'table_to_df_to_dict_split': 7 tests ------------------------------------------------------------------------------------------------
Name (time in us)                                              Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_df_to_dict_split[1-1]             292.4730 (1.0)       1,248.4840 (1.0)         328.4445 (1.0)         65.1897 (1.0)         308.5235 (1.0)         19.1895 (1.0)       239;337  3,044.6546 (1.0)        2880           1
test_benchmark_table_to_df_to_dict_split[100-10]        1,612.4700 (5.51)      5,695.8490 (4.56)      1,788.6228 (5.45)       297.3767 (4.56)      1,687.2415 (5.47)       164.9000 (8.59)        44;49    559.0894 (0.18)        414           1
test_benchmark_table_to_df_to_dict_split[500-10]        4,761.2470 (16.28)     6,012.4680 (4.82)      5,132.0821 (15.63)      205.0396 (3.15)      5,075.7650 (16.45)      134.7735 (7.02)        32;25    194.8527 (0.06)        185           1
test_benchmark_table_to_df_to_dict_split[1000-10]       8,918.7490 (30.49)    10,755.6310 (8.61)      9,315.9055 (28.36)      332.0226 (5.09)      9,209.9590 (29.85)      323.4410 (16.86)        14;7    107.3433 (0.04)         93           1
test_benchmark_table_to_df_to_dict_split[100-100]      12,078.8970 (41.30)    14,270.0050 (11.43)    12,804.6950 (38.99)      446.3205 (6.85)     12,664.8375 (41.05)      611.8770 (31.89)        21;1     78.0964 (0.03)         66           1
test_benchmark_table_to_df_to_dict_split[500-100]      39,707.6090 (135.77)   62,545.1180 (50.10)    42,240.0775 (128.61)   4,805.8505 (73.72)    40,573.9800 (131.51)   1,737.0518 (90.52)         2;3     23.6742 (0.01)         25           1
test_benchmark_table_to_df_to_dict_split[1000-100]     76,744.4330 (262.40)   82,625.2950 (66.18)    79,608.7361 (242.38)   1,793.0131 (27.50)    79,650.5700 (258.17)   3,014.5758 (157.10)        6;0     12.5614 (0.00)         13           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------------------- benchmark 'table_to_dict_split': 7 tests -------------------------------------------------------------------------------------------------
Name (time in us)                                        Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers           OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_dict_split[1-1]               4.3920 (1.0)         177.9230 (1.0)           5.0188 (1.0)          2.5064 (1.0)           4.7640 (1.0)          0.2140 (1.0)      857;3511  199,248.9962 (1.0)       75724           1
test_benchmark_table_to_dict_split[100-10]          540.8020 (123.13)    5,980.8420 (33.61)       672.6449 (134.02)     218.4706 (87.17)       594.7550 (124.84)     134.7850 (629.84)    147;130    1,486.6686 (0.01)       1772           1
test_benchmark_table_to_dict_split[500-10]        2,848.5880 (648.59)    4,387.3680 (24.66)     3,219.1506 (641.41)     295.3388 (117.83)    3,131.7310 (657.37)     429.6425 (>1000.0)      67;3      310.6410 (0.00)        260           1
test_benchmark_table_to_dict_split[100-100]       4,582.8350 (>1000.0)   7,278.2570 (40.91)     5,169.3948 (>1000.0)    463.5783 (184.96)    5,054.2350 (>1000.0)    650.5533 (>1000.0)      52;5      193.4462 (0.00)        195           1
test_benchmark_table_to_dict_split[1000-10]       5,593.5770 (>1000.0)   7,809.8800 (43.89)     6,034.2001 (>1000.0)    365.7258 (145.92)    5,925.5185 (>1000.0)    340.1505 (>1000.0)     20;10      165.7220 (0.00)        140           1
test_benchmark_table_to_dict_split[500-100]      23,270.2010 (>1000.0)  29,009.8050 (163.05)   25,429.2165 (>1000.0)  1,804.3129 (719.89)   24,836.5200 (>1000.0)  2,892.0028 (>1000.0)      13;0       39.3248 (0.00)         43           1
test_benchmark_table_to_dict_split[1000-100]     47,185.5840 (>1000.0)  56,529.3630 (317.72)   50,485.3410 (>1000.0)  2,898.7415 (>1000.0)  49,391.8520 (>1000.0)  3,534.4258 (>1000.0)       5;0       19.8077 (0.00)         19           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## DICT
```
------------------------------------------------------------------------------------------------- benchmark 'table_to_df_to_dict_type': 7 tests -------------------------------------------------------------------------------------------------
Name (time in us)                                             Min                     Max                   Mean                StdDev                 Median                   IQR            Outliers         OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_df_to_dict_type[1-1]             292.9920 (1.0)          827.7700 (1.0)         344.7057 (1.0)         73.4789 (1.0)         310.8920 (1.0)         60.6783 (1.0)         49;30  2,901.0257 (1.0)         559           1
test_benchmark_table_to_df_to_dict_type[100-10]        1,705.7550 (5.82)       3,885.4590 (4.69)      1,898.6449 (5.51)       228.0048 (3.10)      1,793.7920 (5.77)       278.4262 (4.59)        88;12    526.6914 (0.18)        549           1
test_benchmark_table_to_df_to_dict_type[500-10]        5,646.4250 (19.27)      8,496.7460 (10.26)     6,268.5626 (18.19)      570.0120 (7.76)      6,068.4480 (19.52)      637.6370 (10.51)        19;6    159.5262 (0.05)        126           1
test_benchmark_table_to_df_to_dict_type[1000-10]      11,330.8500 (38.67)     36,794.5300 (44.45)    13,314.3057 (38.63)    2,823.4943 (38.43)    12,996.9785 (41.81)      272.0120 (4.48)         1;11     75.1072 (0.03)         74           1
test_benchmark_table_to_df_to_dict_type[100-100]      13,610.3670 (46.45)     28,929.9160 (34.95)    15,596.7114 (45.25)    2,253.6271 (30.67)    14,965.9455 (48.14)    2,792.3685 (46.02)         6;1     64.1161 (0.02)         64           1
test_benchmark_table_to_df_to_dict_type[500-100]      54,452.6700 (185.85)    66,485.6390 (80.32)    60,025.4183 (174.14)   3,560.1763 (48.45)    59,428.3270 (191.15)   3,839.5605 (63.28)         7;0     16.6596 (0.01)         17           1
test_benchmark_table_to_df_to_dict_type[1000-100]     94,061.6810 (321.04)   104,238.1750 (125.93)   98,710.8016 (286.36)   3,400.6859 (46.28)    98,213.5535 (315.91)   4,252.8310 (70.09)         4;0     10.1306 (0.00)         10           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


------------------------------------------------------------------------------------------------- benchmark 'table_to_dict_type': 7 tests --------------------------------------------------------------------------------------------------
Name (time in us)                                       Min                    Max                   Mean                StdDev                 Median                   IQR            Outliers           OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark_table_to_dict_type[1-1]               4.2640 (1.0)         112.4050 (1.0)           4.8105 (1.0)          2.2523 (1.0)           4.5740 (1.0)          0.1720 (1.0)      855;1778  207,879.9438 (1.0)       76214           1
test_benchmark_table_to_dict_type[100-10]          650.7230 (152.61)    2,190.1980 (19.48)       716.7640 (149.00)     123.7935 (54.96)       667.9385 (146.03)      51.7560 (300.91)    107;176    1,395.1594 (0.01)       1104           1
test_benchmark_table_to_dict_type[500-10]        3,230.8040 (757.69)    4,130.9470 (36.75)     3,431.3481 (713.31)     150.6324 (66.88)     3,394.5120 (742.13)      69.6973 (405.22)      30;34      291.4306 (0.00)        231           1
test_benchmark_table_to_dict_type[100-100]       5,625.4760 (>1000.0)  12,671.0810 (112.73)    6,416.6121 (>1000.0)    824.3187 (365.99)    6,056.3085 (>1000.0)    889.9320 (>1000.0)      27;4      155.8455 (0.00)        162           1
test_benchmark_table_to_dict_type[1000-10]       6,330.4170 (>1000.0)   7,334.8970 (65.25)     6,686.9080 (>1000.0)    175.1534 (77.77)     6,646.6075 (>1000.0)    274.5260 (>1000.0)      34;2      149.5459 (0.00)        114           1
test_benchmark_table_to_dict_type[500-100]      28,239.3630 (>1000.0)  32,148.5230 (286.01)   29,738.7197 (>1000.0)  1,040.5511 (462.00)   29,687.7300 (>1000.0)  1,566.4440 (>1000.0)      12;0       33.6262 (0.00)         34           1
test_benchmark_table_to_dict_type[1000-100]     60,424.7200 (>1000.0)  88,440.0680 (786.80)   65,843.7432 (>1000.0)  7,692.2937 (>1000.0)  62,593.4070 (>1000.0)  5,385.2205 (>1000.0)       2;2       15.1875 (0.00)         15           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```